### PR TITLE
This is improving the readme phrasing

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -3,8 +3,7 @@ English | [简体中文](./README-zh_CN.md)
 # You Don't Need JavaScript
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/you-dont-need/javascript)
 
-Please note these demos should be considered as CSS "Proofs of Concepts". They may have serious issues from accessibility point of view (keyboard navigation, speech synthesis, etc.), or progressive enhancement/degradation/etc.
-
+Please note demos may have serious issues from an accessibility point of view (keyboard navigation, speech synthesis, etc.), or progressive enhancement/degradation/etc.
 
 ### Style Guide:
 

--- a/README.MD
+++ b/README.MD
@@ -3,7 +3,7 @@ English | [简体中文](./README-zh_CN.md)
 # You Don't Need JavaScript
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/you-dont-need/javascript)
 
-Please note demos may have serious issues from an accessibility point of view (keyboard navigation, speech synthesis, etc.), or progressive enhancement/degradation/etc.
+Please note demos may have serious issues regarding accessibility (keyboard navigation, speech synthesis, etc.), or progressive enhancement/degradation/etc.
 
 ### Style Guide:
 


### PR DESCRIPTION
The phrasing of the first few sentences of the readme seems to be a hot topic in the issues. This is my attempt to make it more clear. 

This is addressing the following issues:
1. https://github.com/you-dont-need/You-Dont-Need-JavaScript/issues/108
2. https://github.com/you-dont-need/You-Dont-Need-JavaScript/issues/77
3. https://github.com/you-dont-need/You-Dont-Need-JavaScript/issues/76