### PR TITLE
 Correction of Theme Toggle Button Position and Style on Main Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,9 @@
 				font-size: 14px;
 				padding: 4px 8px;
 			}
+			.dark-mode-toggle{
+				display: none;
+			}
 		}
 
 		@media (max-width: 500px) {
@@ -232,12 +235,15 @@
 		@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700&display=swap');
 
 		.dark-mode-toggle {
-			position: fixed;
-			top: 20px;
+			/*display: flex;
+			justify-content: end;*/
+			margin: 10px;
+			position: absolute;
+			top: 60px;
 			right: 20px;
 			z-index: 1000;
 		}
-
+		
 		.dark-mode-toggle label {
 			position: relative;
 			width: 80px;
@@ -246,9 +252,11 @@
 			background: #d9d9d9;
 			border-radius: 100px;
 			cursor: pointer;
-			box-shadow: inset 0px 5px 15px rgba(0, 0, 0, 0.2), inset 0px -5px 15px rgba(255, 255, 255, 0.2);
+			box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.15),
+						-5px -5px 10px rgba(255, 255, 255, 0.7);
+			transition: background 0.3s ease, box-shadow 0.3s ease;
 		}
-
+		
 		.dark-mode-toggle label:after {
 			content: '';
 			position: absolute;
@@ -258,23 +266,28 @@
 			border-radius: 100px;
 			top: 3px;
 			left: 3px;
-			transition: 0.5s;
-			box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+			transition: left 0.5s ease, background 0.3s ease;
+			box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.2),
+						-3px -3px 6px rgba(255, 255, 255, 0.6);
 		}
-
-		.dark-mode-toggle input:checked~label:after {
-			left: 74px;
-			transform: translateX(-100%);
-			background: linear-gradient(180deg, #777, #3a3a3a);
-		}
-
-		.dark-mode-toggle input:checked~label {
+		
+		.dark-mode-toggle input:checked ~ label {
 			background: #242424;
+			box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.4),
+						-5px -5px 10px rgba(255, 255, 255, 0.05);
 		}
-
+		
+		.dark-mode-toggle input:checked ~ label:after {
+			left: 43px;
+			background: linear-gradient(180deg, #777, #3a3a3a);
+			box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.3),
+						-2px -2px 5px rgba(255, 255, 255, 0.1);
+		}
+		
 		.dark-mode-toggle input {
 			display: none;
 		}
+		
 
 		/* Remove the old button styles */
 		#toggleButton {
@@ -288,10 +301,7 @@
 	<!-- <button id="toggleButton">🌙 Dark Mode</button> -->
 
 	<!-- Add the new dark mode toggle -->
-	<div class="dark-mode-toggle">
-		<input type="checkbox" id="dark-mode">
-		<label for="dark-mode"></label>
-	</div>
+	
 
 	<section id="pageSection">
 		<div id="google_element"></div>
@@ -315,6 +325,10 @@
 				console.error("Error loading Google Translate script:", error);
 			}
 		</script>
+		<div class="dark-mode-toggle">
+			<input type="checkbox" id="dark-mode">
+			<label for="dark-mode"></label>
+		</div>
 		<header>
 			<h1><a href="https://github.com/you-dont-need/You-Dont-Need-JavaScript">You Dont Need JavaScript</a></h1>
 			<p class="description">Explore the power of pure CSS with our collection of interactive demos and examples.


### PR DESCRIPTION
 I initially suggested using `absolute` positioning, but after reviewing the layout, I think `relative` positioning combined with `justify-content: flex-end` to align the button on the right might work better. One benefit of using `relative` is that the button won't go outside the page section or over its border, and it aligns better with the page's uppermost text. 

For now, I've commented out the `relative` styles and kept the `absolute` positioning as originally discussed. If you think switching to `relative` positioning would work better after seeing the issue, let me know, and I can update the styles accordingly.

here's the updated theme switch toggle :
![image](https://github.com/user-attachments/assets/ff977cf6-3a17-43ef-9835-9b4f75bd0272)

when position is absolute : 
![image](https://github.com/user-attachments/assets/54387e24-4987-48a4-9da9-90df2e00b934)

when position is relative: 
![image](https://github.com/user-attachments/assets/53db1fb9-f1de-4e8b-a463-a5abf5820667)
