### PR TITLE
Fixing text overlapping while making the screen small

### DIFF
--- a/Badges/Badge-design-2/index.html
+++ b/Badges/Badge-design-2/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
+<head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -11,54 +11,39 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
-    <title>Badge design with Font Awesome</title>
-  </head>
-  <body>
-    <div class="flex gap-5 mt-44 justify-center items-center px-80">
-      <!-- Open Status Badge -->
-      <div
-        class="flex w-full gap-3 border p-2 pr-6 rounded-2xl bg-green-200 mb-4"
-      >
-        <div
-          class="bg-green-500 w-12 h-12 flex justify-center items-center rounded-xl"
-        >
-          <!-- Unlock Icon -->
-          <i class="fas fa-lock-open text-white text-2xl"></i>
+    <title>Badge Design with Font Awesome</title>
+</head>
+<body>
+    <div class="flex flex-col gap-5 mt-10 mx-5 md:mx-80">
+        <!-- Open Status Badge -->
+        <div class="flex gap-3 border p-2 pr-6 rounded-2xl bg-green-200">
+            <div class="bg-green-500 w-12 h-12 flex justify-center items-center rounded-xl">
+                <i class="fas fa-lock-open text-white text-2xl"></i>
+            </div>
+            <div class="flex flex-col justify-center">
+                <p class="text-black font-bold text-sm md:text-base">MARKET remains open today.</p>
+            </div>
         </div>
-        <div class="w-3/4 flex flex-col justify-center">
-          <p class="text-black font-bold">MARKET remains open today.</p>
-        </div>
-      </div>
 
-      <!-- Closed Status Badge -->
-      <div
-        class="flex w-full gap-3 border p-2 pr-6 rounded-2xl bg-red-200 mb-4"
-      >
-        <div
-          class="bg-red-500 w-12 h-12 flex justify-center items-center rounded-xl"
-        >
-          <!-- Lock Icon -->
-          <i class="fas fa-lock text-white text-2xl"></i>
+        <!-- Closed Status Badge -->
+        <div class="flex gap-3 border p-2 pr-6 rounded-2xl bg-red-200">
+            <div class="bg-red-500 w-12 h-12 flex justify-center items-center rounded-xl">
+                <i class="fas fa-lock text-white text-2xl"></i>
+            </div>
+            <div class="flex flex-col justify-center">
+                <p class="text-black font-bold text-sm md:text-base">MARKET remains closed today.</p>
+            </div>
         </div>
-        <div class="w-3/4 flex flex-col justify-center">
-          <p class="text-black font-bold">MARKET remains closed today.</p>
-        </div>
-      </div>
 
-      <!-- Not Announced Status Badge -->
-      <div
-        class="flex w-full gap-3 whitespace-nowrap border p-2 pr-6 rounded-2xl bg-yellow-200 mb-4"
-      >
-        <div
-          class="bg-yellow-500 w-12 h-12 flex justify-center items-center rounded-xl"
-        >
-          <!-- Question Mark Icon -->
-          <i class="fas fa-question-circle text-white text-2xl"></i>
+        <!-- Not Announced Status Badge -->
+        <div class="flex gap-3 border p-2 pr-6 rounded-2xl bg-yellow-200">
+            <div class="bg-yellow-500 w-12 h-12 flex justify-center items-center rounded-xl">
+                <i class="fas fa-question-circle text-white text-2xl"></i>
+            </div>
+            <div class="flex flex-col justify-center">
+                <p class="text-black font-bold text-sm md:text-base">MARKET status is not announced.</p>
+            </div>
         </div>
-        <div class="w-3/4 flex flex-col justify-center">
-          <p class="text-black font-bold">MARKET status is not announced.</p>
-        </div>
-      </div>
     </div>
-  </body>
+</body>
 </html>


### PR DESCRIPTION
Changes Made:

    Flex Direction: Changed the main container to a column layout on smaller screens (flex-col), allowing badges to stack vertically.
    Margin and Padding: Adjusted margins for smaller screens with mx-5 and kept md:mx-80 for larger screens.
    Responsive Text Sizes: Added responsive text sizes using text-sm for small screens and md:text-base for larger screens to ensure the text fits better.

These adjustments will help maintain a clear layout across different screen sizes without overlapping text.

Earlier:
![image](https://github.com/user-attachments/assets/875a891a-ce4f-4953-b6f7-64b3aca3ecac)

Updated:
![image](https://github.com/user-attachments/assets/9b27afc0-e0b1-42c6-b031-31863c42663f)
