### PR TITLE
change navigation hover from gray to blue-pink gradient

### DIFF
--- a/Bitcoin-website/index.html
+++ b/Bitcoin-website/index.html
@@ -61,7 +61,11 @@
         }
 
         .menu ul li:hover {
-            color: #b2b1b1;
+            background: linear-gradient(90deg, #19d7f8, #fd00da);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            font-weight: bold;
+            transition: all 0.3s ease;
         }
 
         .active {


### PR DESCRIPTION
**Pull Request: Update Navigation Hover Effect**

Hello 👋,

This PR updates the **navigation menu hover effect**.
Previously, the menu items (Home, Service, Product, Contact) changed to **gray** on hover, which didn’t match the website’s theme.

 **Changes Made:**

* Added a **blue → pink gradient hover effect** (`#19d7f8` → `#fd00da`) for navigation items.
* This aligns the navigation hover state with the website’s overall theme colors.

**Preview:**

* On hover, the navigation items now display a gradient text effect consistent with the site’s design.

 **Notes:**

I’m a beginner in open source and contributing under **Hacktoberfest** 🌸.
Please let me know if any improvements are needed!

Thank you 🙏
