### PR TITLE
feat: Add Pure CSS Dismissible Alert Demo (No JS needed)

### DIFF
--- a/Pure-CSS-Dismissible-Alert/index.html
+++ b/Pure-CSS-Dismissible-Alert/index.html
@@ -3,26 +3,67 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pure CSS Dismissible Alert</title>
+    <title>Pure CSS Dismissible Alerts (Multiple Types)</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <h1>Pure CSS Dismissible Alerts</h1>
+    <p class="instruction">Click the 'X' to dismiss. All functionality is pure HTML/CSS.</p>
 
-    <input type="checkbox" id="alert-toggle" class="alert-toggle" hidden>
-
+    <!-- SUCCESS ALERT -->
+    <input type="checkbox" id="alert-success-toggle" class="alert-toggle" hidden>
     <div class="alert-container">
-        <div class="alert-box">
+        <div class="alert-box alert--success">
             <h3 class="alert-title">Success! 🎉</h3>
             <p class="alert-message">
-                Your settings have been saved. This alert is dismissed with **only CSS**!
+                Your settings have been saved successfully. (Dismissed with CSS only)
             </p>
-            <label for="alert-toggle" class="alert-close" role="button" aria-label="Dismiss alert">
+            <label for="alert-success-toggle" class="alert-close" role="button" aria-label="Dismiss success alert">
                 &times;
             </label>
         </div>
-        <p class="content-after-dismiss">
-            This content becomes visible when the alert is dismissed (via CSS transition).
-        </p>
+    </div>
+
+    <!-- ERROR ALERT -->
+    <input type="checkbox" id="alert-error-toggle" class="alert-toggle" hidden>
+    <div class="alert-container">
+        <div class="alert-box alert--error">
+            <h3 class="alert-title">Error! 🚫</h3>
+            <p class="alert-message">
+                File upload failed due to insufficient permissions.
+            </p>
+            <label for="alert-error-toggle" class="alert-close" role="button" aria-label="Dismiss error alert">
+                &times;
+            </label>
+        </div>
+    </div>
+
+    <!-- WARNING ALERT -->
+    <input type="checkbox" id="alert-warning-toggle" class="alert-toggle" hidden>
+    <div class="alert-container">
+        <div class="alert-box alert--warning">
+            <h3 class="alert-title">Warning! ⚠️</h3>
+            <p class="alert-message">
+                Session expiring soon. Please save your work to prevent data loss.
+            </p>
+            <label for="alert-warning-toggle" class="alert-close" role="button" aria-label="Dismiss warning alert">
+                &times;
+            </label>
+        </div>
+    </div>
+
+    <!-- INFO ALERT -->
+    <input type="checkbox" id="alert-info-toggle" class="alert-toggle" hidden>
+    <div class="alert-container">
+        <div class="alert-box alert--info">
+            <h3 class="alert-title">Information 💡</h3>
+            <p class="alert-message">
+                New features are available. Check the changelog for details.
+            </p>
+            <label for="alert-info-toggle" class="alert-close" role="button" aria-label="Dismiss info alert">
+                &times;
+            </label>
+        </div>
     </div>
 
 </body>

--- a/Pure-CSS-Dismissible-Alert/style.css
+++ b/Pure-CSS-Dismissible-Alert/style.css
@@ -1,37 +1,50 @@
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    background-color: #f0f2f5;
+    font-family: 'Inter', Arial, sans-serif; /* Using Inter as per instructions */
+    background-color: #f4f7f6;
     display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    min-height: 100vh;
-    padding-top: 50px;
+    flex-direction: column;
+    align-items: center;
+    padding: 30px 20px;
     margin: 0;
+    min-height: 100vh;
+}
+
+h1 {
+    color: #333;
+    font-size: 2rem;
+    margin-bottom: 10px;
+}
+
+.instruction {
+    color: #666;
+    margin-bottom: 40px;
+    font-style: italic;
 }
 
 .alert-container {
     width: 90%;
     max-width: 600px;
+    margin-bottom: 20px;
 }
 
-/* --- ALERT BOX STYLES (VISIBLE BY DEFAULT) --- */
+/* --- BASE ALERT STYLES (Applies to all) --- */
 .alert-box {
-    background-color: #d4edda;
-    color: #155724;
-    border: 1px solid #c3e6cb;
-    border-radius: 5px;
+    border-radius: 8px;
     padding: 20px;
-    margin-bottom: 20px;
     position: relative;
     opacity: 1;
     transform: translateY(0);
-    transition: opacity 0.4s ease-out, transform 0.4s ease-out, margin-bottom 0.4s ease-out, padding 0.4s ease-out, height 0.4s ease-out;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    transition: opacity 0.4s ease-out, transform 0.4s ease-out, margin-bottom 0.4s ease-out, height 0.4s ease-out, padding 0.4s ease-out;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    border-left: 5px solid; /* For colored accent */
+    overflow: hidden; /* Crucial for transition */
+    min-height: 80px; /* Ensure consistent initial height */
 }
 
 .alert-title {
     margin-top: 0;
     font-size: 1.25rem;
+    font-weight: 600;
 }
 
 .alert-message {
@@ -46,7 +59,6 @@ body {
     transform: translateY(-50%);
     font-size: 1.5rem;
     cursor: pointer;
-    color: #155724;
     text-decoration: none;
     line-height: 1;
     opacity: 0.7;
@@ -57,34 +69,58 @@ body {
     opacity: 1;
 }
 
-/* --- THE PURE CSS MAGIC (CHECKBOX HACK) --- */
+/* --- THEME COLORS --- */
 
-/* 1. Hide the element by changing its style when the checkbox is checked */
+/* SUCCESS (Green) */
+.alert--success {
+    background-color: #d4edda;
+    color: #155724;
+    border-left-color: #28a745;
+}
+.alert--success .alert-close { color: #155724; }
+
+/* ERROR (Red) */
+.alert--error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border-left-color: #dc3545;
+}
+.alert--error .alert-close { color: #721c24; }
+
+/* WARNING (Yellow/Orange) */
+.alert--warning {
+    background-color: #fff3cd;
+    color: #856404;
+    border-left-color: #ffc107;
+}
+.alert--warning .alert-close { color: #856404; }
+
+/* INFO (Blue) */
+.alert--info {
+    background-color: #d1ecf1;
+    color: #0c5460;
+    border-left-color: #17a2b8;
+}
+.alert--info .alert-close { color: #0c5460; }
+
+
+/* --- THE PURE CSS MAGIC (DISMISSAL LOGIC) --- */
+
+/* Selects the sibling alert-container when the toggle is checked */
+.alert-toggle:checked + .alert-container {
+    /* Set container height/padding to 0 */
+    max-height: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding: 0;
+    transition: max-height 0.4s ease-out, margin-bottom 0.4s ease-out;
+}
+
+/* Hide the inner content once the container collapses */
 .alert-toggle:checked + .alert-container .alert-box {
     opacity: 0;
-    transform: translateY(-10px); /* Move it up slightly for the dismissal animation */
-    /* Collapse the box visually and remove it from flow */
-    height: 0;
-    padding: 0 20px;
-    margin-bottom: 0;
-    border: none;
-    overflow: hidden;
+    padding-top: 0;
+    padding-bottom: 0;
+    transform: translateY(-10px);
+    transition: opacity 0.3s ease-out 0.1s, transform 0.3s ease-out 0.1s, padding 0.3s ease-out 0.1s;
 }
-
-/* 2. Hide any content that should only be visible when the alert is gone */
-.content-after-dismiss {
-    opacity: 0;
-    transform: translateY(-20px);
-    transition: opacity 0.4s ease-out 0.4s, transform 0.4s ease-out 0.4s;
-    font-style: italic;
-    color: #666;
-    margin-top: 10px;
-}
-
-/* 3. Show the 'after dismiss' content when the checkbox is checked */
-.alert-toggle:checked + .alert-container .content-after-dismiss {
-    opacity: 1;
-    transform: translateY(0);
-}
-
-/* Note: The 'alert-toggle' itself is hidden using the 'hidden' attribute in HTML. */


### PR DESCRIPTION
Hello! I'm submitting this contribution for Hacktoberfest.

This PR introduces a new component: a Pure CSS Dismissible Alert/Notification.

What it does:
Demonstrates how to create a typical website alert (like a cookie banner or success message) that can be permanently closed by the user.

The dismissal functionality is achieved entirely using the Checkbox Hack (<input type="checkbox" hidden> combined with the CSS sibling selector :checked).

No JavaScript is used for toggling visibility or animating the exit.