### PR TITLE
Fix responsive issues: CSS-only hamburger menu and navbar adjustments

### DIFF
--- a/Netflix-Clone-v2/index.html
+++ b/Netflix-Clone-v2/index.html
@@ -22,18 +22,31 @@
 </head>
 <body>
 
-  <header class="navbar">
-    <div class="logo">
-      <a href="https://joegeorge022.github.io/Netflix-Clone-2/"><img src="netlfix_logo.png" alt="Netflix Logo"></a>
-    </div>
-    <div class="menu">
-      <a href="#content1">Home</a>
-      <a href="#content1">TV Shows</a>
-      <a href="#content1">Movies</a>
-      <a href="#content1">Latest</a>
-      <a href="#content1">My List</a>
-    </div>
-  </header>
+    <header class="navbar">
+  <div class="logo">
+    <a href="https://joegeorge022.github.io/Netflix-Clone-2/">
+      <img src="netlfix_logo.png" alt="Netflix Logo">
+    </a>
+  </div>
+
+  <!-- CSS-Only Hamburger (Checkbox Hack) -->
+  <input type="checkbox" id="menu-toggle">
+  <label for="menu-toggle" class="hamburger">
+    <span></span>
+    <span></span>
+    <span></span>
+  </label>
+
+  <nav class="menu">
+    <a href="#content1">Home</a>
+    <a href="#content1">TV Shows</a>
+    <a href="#content1">Movies</a>
+    <a href="#content1">Latest</a>
+    <a href="#content1">My List</a>
+  </nav>
+</header>
+
+
 
   <section class="hero">
     <div class="hero-content">

--- a/Netflix-Clone-v2/styles.css
+++ b/Netflix-Clone-v2/styles.css
@@ -93,3 +93,151 @@ body {
   color: #fff;
   font-size: 14px;
 }
+
+
+@media (max-width: 768px) {
+
+  
+  body {
+    overflow-x: hidden;
+    background-attachment: scroll;
+    background-position: center;
+  }
+
+  
+  .navbar {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 15px 0;
+  }
+
+  .menu {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .menu a {
+    font-size: 1rem;
+  }
+
+  .logo img {
+    width: 120px;
+    height: auto;
+  }
+
+  
+  .hero {
+    text-align: center;
+    padding: 50px 20px;
+    background-size: cover;
+  }
+
+  .hero-content h1 {
+    font-size: 1.8rem;
+  }
+
+  .hero-content p {
+    font-size: 1rem;
+  }
+
+  .cta-btn {
+    padding: 10px 20px;
+    font-size: 1rem;
+  }
+
+  
+  .content-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 10px;
+    padding: 0 10px;
+  }
+
+  .content-grid img {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+  }
+
+  
+  .content-section h2 {
+    font-size: 1.4rem;
+    text-align: center;
+    margin-bottom: 15px;
+  }
+
+  
+  .footer {
+    text-align: center;
+    padding: 20px;
+    font-size: 0.9rem;
+  }
+}
+#menu-toggle {
+  display: none;
+}
+
+.hamburger {
+  display: none;
+  flex-direction: column;
+  cursor: pointer;
+  gap: 5px;
+  position: absolute;
+  top: 25px;
+  right: 25px;
+  z-index: 1100;
+}
+
+.hamburger span {
+  width: 25px;
+  height: 3px;
+  background-color: #fff;
+  border-radius: 2px;
+  transition: all 0.3s;
+}
+
+@media (max-width: 768px) {
+  .hamburger {
+    display: flex;
+  }
+
+  .menu {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    width: 60%;
+    max-width: 250px;
+    background-color: #141414;
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100%;
+    padding: 60px 20px 20px 20px;
+    transform: translateX(100%);
+    transition: transform 0.3s ease-in-out;
+    z-index: 1000;
+  }
+
+  #menu-toggle:checked + .hamburger + .menu {
+    transform: translateX(0);
+  }
+
+  .menu a {
+    font-size: 1.2rem;
+    margin: 10px 0;
+  }
+}
+#menu-toggle:checked + .hamburger span:nth-child(1) {
+  transform: rotate(45deg) translate(5px, 5px);
+}
+
+#menu-toggle:checked + .hamburger span:nth-child(2) {
+  opacity: 0;
+}
+
+#menu-toggle:checked + .hamburger span:nth-child(3) {
+  transform: rotate(-45deg) translate(6px, -6px);
+}


### PR DESCRIPTION
**Issue Addressed:**  
#<insert-issue-number> – The Netflix-Clone-v2 interface breaks on phone-sized devices (viewport width < 768px). Observed problems included overlapping text/images, non-adaptive grids, and cluttered movie posters.

**Changes Implemented:**  
- Added CSS-only hamburger menu for mobile navigation.  
- Navbar slides in from the right on mobile screens.  
- Grid layout for movie posters now adapts to smaller screens using `auto-fit` and `minmax`.  
- Adjusted hero section and content text sizes for better readability on mobile.  
- Prevented overlapping of images and text on screens < 768px.  

**Notes:**  
- Solution uses only HTML + CSS; no JavaScript added.  
- Branch: `fix-responses`  

I am new to open source, so any feedback or suggestions are highly appreciated!
