### PR TITLE
Fix: Mobile responsiveness for Netflix-Clone-v2

### DIFF
--- a/Netflix-Clone-v2/styles.css
+++ b/Netflix-Clone-v2/styles.css
@@ -241,3 +241,64 @@ body {
 #menu-toggle:checked + .hamburger span:nth-child(3) {
   transform: rotate(-45deg) translate(6px, -6px);
 }
+
+@media (max-width: 768px) {
+  html, body {
+    overflow-x: hidden;
+  }
+
+  .navbar {
+    position: relative;
+    padding: 10px 15px;
+  }
+
+  .navbar .logo {
+    position: static;
+    margin-bottom: 10px;
+  }
+
+  .hamburger {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+  }
+}
+
+@media (max-width: 600px) {
+  .content-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero {
+    height: auto;
+    padding: 80px 20px;
+  }
+
+  .hero-content h1 {
+    font-size: 1.5rem;
+    line-height: 1.3;
+  }
+
+  .hero-content p {
+    font-size: 0.9rem;
+  }
+
+  .cta-btn {
+    padding: 8px 16px;
+    font-size: 0.9rem;
+  }
+}
+
+@media (max-width: 400px) {
+  .content-grid {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .navbar .logo img {
+    width: 100px;
+  }
+}


### PR DESCRIPTION
**Description:**
This pull request improves the mobile responsiveness of Netflix-Clone-v2 for devices with viewport width below 768px.

**Changes include:**

Added media queries for extra small devices (max-width: 600px, 480px, 400px).

Adjusted the movie grid layout to adapt from 5 → 2 → 1 columns on smaller screens.

Fixed hero section height, text size, and CTA button padding for mobile readability.

Corrected navbar logo and hamburger menu alignment to prevent overlap.

Prevented horizontal scroll and layout overflow on small devices.

These changes ensure the interface is readable, visually consistent, and fully responsive on phones and tablets.