### PR TITLE
Add Accessible CSS-only Tabs demo (Tabs/Accessible-Tabs)

### DIFF
--- a/Tabs/Accessible-Tabs/README.md
+++ b/Tabs/Accessible-Tabs/README.md
@@ -1,0 +1,27 @@
+```markdown
+# Accessible CSS-only Tabs
+
+A small demo that implements tabbed content using only HTML and CSS (radio inputs + labels).  
+This shows how to switch panels without JavaScript.
+
+## Files
+- `index.html` — demo HTML
+- `style.css` — styles and layout
+- `README.md` — this file
+
+## How to use
+1. Open `index.html` in your browser.
+2. Click the tab labels to switch panels.
+3. The demo uses `<input type="radio">` and `<label for="...">` to control which panel is displayed.
+
+## Accessibility notes
+- The pattern uses semantic roles: `role="tablist"`, `role="tab"` and `role="tabpanel"`.
+- Keyboard navigation using Tab to focus labels works; however, arrow-key navigation between tabs and advanced focus management require JavaScript for full WAI-ARIA tab behavior. Document this limitation in the demo README so reviewers know it's intentional.
+- Ensure focus-visible styles are present (they are in `style.css`).
+
+## Contribution
+- Add your name and GitHub handle to the "Contributed By" section if you submit this demo.
+- Follow the repository CONTRIBUTING.md: fork → branch → add folder (`Tabs/Accessible-Tabs/`) → update top-level README index if needed → PR.
+
+## Contributed by
+- Your Name — https://github.com/itsmeananyasrivastava

--- a/Tabs/Accessible-Tabs/index.html
+++ b/Tabs/Accessible-Tabs/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Accessible CSS-only Tabs — You Don't Need JavaScript</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="demo">
+    <h1 class="title">Accessible CSS-only Tabs</h1>
+
+    <div class="tabs" role="tablist" aria-label="Sample tabs">
+      <!-- Radio controls (visually hidden but focusable) -->
+      <input type="radio" name="tabs" id="tab1" checked>
+      <label for="tab1" role="tab" aria-controls="panel1" class="tab">Overview</label>
+
+      <input type="radio" name="tabs" id="tab2">
+      <label for="tab2" role="tab" aria-controls="panel2" class="tab">Features</label>
+
+      <input type="radio" name="tabs" id="tab3">
+      <label for="tab3" role="tab" aria-controls="panel3" class="tab">Accessibility</label>
+
+      <!-- Panels -->
+      <section id="panel1" class="panel" role="tabpanel" tabindex="0" aria-labelledby="tab1">
+        <h2>Overview</h2>
+        <p>This demo shows how to implement tabbed content with only HTML and CSS using radio buttons and labels. Switching tabs uses :checked state; no JavaScript required.</p>
+      </section>
+
+      <section id="panel2" class="panel" role="tabpanel" tabindex="0" aria-labelledby="tab2" hidden>
+        <h2>Features</h2>
+        <ul>
+          <li>Pure HTML + CSS (no JavaScript)</li>
+          <li>Responsive layout</li>
+          <li>Visible focus styles for keyboard users</li>
+        </ul>
+      </section>
+
+      <section id="panel3" class="panel" role="tabpanel" tabindex="0" aria-labelledby="tab3" hidden>
+        <h2>Accessibility</h2>
+        <p>This pattern uses semantic roles: <code>role="tablist"</code>, <code>role="tab"</code> and <code>role="tabpanel"</code>. Note: full WAI-ARIA tab keyboard support (arrow key navigation & roving focus) requires JS; this demo documents that limitation.</p>
+      </section>
+    </div>
+  </main>
+</body>
+</html>

--- a/Tabs/Accessible-Tabs/style.css
+++ b/Tabs/Accessible-Tabs/style.css
@@ -1,0 +1,120 @@
+:root{
+  --accent:#4f46e5;
+  --muted:#6b7280;
+  --bg:#0f172a;
+  --card:#0b1220;
+  --radius:10px;
+  --gap:12px;
+  --text:#e6eef8;
+}
+
+*{box-sizing:border-box}
+body{
+  font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial;
+  margin:0;
+  min-height:100vh;
+  color:var(--text);
+  background:linear-gradient(180deg,#06102a 0%, #071024 50%, #071028 100%);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:32px;
+}
+
+.demo{
+  width:100%;
+  max-width:900px;
+}
+
+.title{
+  font-size:1.4rem;
+  margin:0 0 16px 0;
+  color:var(--text);
+  text-align:center;
+}
+
+.tabs{
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+  border-radius:var(--radius);
+  padding:16px;
+  box-shadow: 0 6px 22px rgba(2,6,23,0.6);
+  display:grid;
+  grid-template-columns: repeat(3, minmax(0,1fr));
+  gap:var(--gap);
+  align-items:start;
+}
+
+/* Visually hide inputs but keep them accessible/focusable */
+input[type="radio"]{
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+/* Style labels as tabs */
+.tab{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:10px 14px;
+  background:transparent;
+  color:var(--muted);
+  border-radius:8px;
+  cursor:pointer;
+  user-select:none;
+  transition: all 200ms ease;
+  border:1px solid transparent;
+  font-weight:600;
+}
+
+/* When the associated input is focused, style the label so keyboard users see it */
+input[type="radio"]:focus + .tab,
+.tab:focus{
+  outline:3px solid rgba(79,70,229,0.18);
+  outline-offset:2px;
+}
+
+/* Layout: labels across top and panels below on small screens */
+@media (max-width:640px){
+  .tabs{grid-template-columns: 1fr; grid-auto-rows: auto; }
+  .tab{ justify-content:flex-start; }
+}
+
+/* Panels style */
+.panel{
+  grid-column: 1 / -1; /* span full width */
+  background: linear-gradient(180deg, rgba(255,255,255,0.01), rgba(255,255,255,0.02));
+  padding:18px;
+  margin-top:8px;
+  border-radius:8px;
+  border:1px solid rgba(255,255,255,0.03);
+  color:var(--text);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.02);
+}
+
+/* Default hidden panels; show the one matching the :checked sibling */
+.panel{ display:none; }
+#tab1:checked ~ #panel1{ display:block; }
+#tab2:checked ~ #panel2{ display:block; }
+#tab3:checked ~ #panel3{ display:block; }
+
+/* Active tab visual: style label for the checked input */
+#tab1:checked + label[for="tab1"],
+#tab2:checked + label[for="tab2"],
+#tab3:checked + label[for="tab3"]{
+  color:var(--text);
+  background: linear-gradient(90deg, rgba(79,70,229,0.12), rgba(79,70,229,0.06));
+  border:1px solid rgba(79,70,229,0.2);
+  box-shadow: 0 6px 18px rgba(15,23,42,0.6);
+  transform: translateY(-4px);
+}
+
+/* Small enhancements */
+.panel h2{ margin-top:0; color:var(--accent); }
+.panel p, .panel ul{ color: #cbd5e1; line-height:1.45; }


### PR DESCRIPTION
This PR adds a new demo: "Accessible CSS-only Tabs" (Tabs/Accessible-Tabs). The demo demonstrates how to implement a tabbed interface using only HTML and CSS (radio inputs + labels). Files included:

Tabs/Accessible-Tabs/index.html
Tabs/Accessible-Tabs/style.css
Tabs/Accessible-Tabs/README.md

<img width="1479" height="737" alt="image" src="https://github.com/user-attachments/assets/26d87e8a-a80f-4cfe-ac35-247e7ab9e0e4" />
